### PR TITLE
Add Logic to Toggle Display of Sponsor Pages

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -139,8 +139,8 @@ peri:
 # If false, hides sponsors link in navigation and footer
 show-sponsors: false
 # If true, any "Sponsors" links will go to /prospectus instead of /sponsors
-call-for-sponsors: true
-homepage-sponsor-button: true
+call-for-sponsors: false
+homepage-sponsor-button: false
 # URL to document
 prospectus-document: '/assets/2021_c4l_Infosheet.pdf'
 sponsor-btn-link: 'https://na.eventscloud.com/sponsor.c4l20'

--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -136,7 +136,7 @@ peri:
 ###########
 # Sponsors
 ###########
-
+# If false, hides sponsors link in navigation and footer
 show-sponsors: false
 # If true, any "Sponsors" links will go to /prospectus instead of /sponsors
 call-for-sponsors: true

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,11 +11,13 @@
             {% link speakers/index.html %}{% else %}{% link speakers/past-keynotes.html %}
             {% endif %}">Speakers</a></li>
 
-            {% if site.data.conf.call-for-sponsors %}
-                <li class="list-inline-item tci"><a href="{{ site.baseurl }}{% link prospectus/index.html %}">Sponsors</a></li>
-            {% else %}
-                {% if site.data.conf.show-sponsors %}
-                    <li class="list-inline-item tci"><a href="{{ site.baseurl }}{% link sponsors/index.html %}">Sponsors</a></li>
+            {% if site.data.conf.show-sponsors %}
+                {% if site.data.conf.call-for-sponsors %}
+                    <li class="list-inline-item tci"><a href="{{ site.baseurl }}{% link prospectus/index.html %}">Sponsors</a></li>
+                {% else %}
+                    {% if site.data.conf.show-sponsors %}
+                        <li class="list-inline-item tci"><a href="{{ site.baseurl }}{% link sponsors/index.html %}">Sponsors</a></li>
+                    {% endif %}
                 {% endif %}
             {% endif %}
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -39,11 +39,14 @@
                 when looking for sponsors before conf, send users to prospectus
                 close to / during conf, send to the list of sponsors page
                 {% endcomment %}
-                {% if site.data.conf.call-for-sponsors %}
-                    <li class="nav-item"><a href="{{ site.baseurl }}{% link prospectus/index.html %}" class="nav-link">Sponsors</a></li>
-                {% else %}
-                    {% if site.data.conf.show-sponsors %}
-                    <li class="nav-item"><a href="{{ site.baseurl }}{% link sponsors/index.html %}" class="nav-link">Sponsors</a></li>
+
+                {% if site.data.conf.show-sponsors%}
+                    {% if site.data.conf.call-for-sponsors %}
+                        <li class="nav-item"><a href="{{ site.baseurl }}{% link prospectus/index.html %}" class="nav-link">Sponsors</a></li>
+                    {% else %}
+                        {% if site.data.conf.show-sponsors %}
+                        <li class="nav-item"><a href="{{ site.baseurl }}{% link sponsors/index.html %}" class="nav-link">Sponsors</a></li>
+                        {% endif %}
                     {% endif %}
                 {% endif %}
 


### PR DESCRIPTION
To Test:
- Toggle `show-sponsors: false` to `show-sponsors: true` in `_data/conf.yml`
- Run `bundle exec jekyll serve`

Sponsor page links should display. Closes #13 

<img width="1023" alt="Screen Shot 2020-11-08 at 7 04 45 PM" src="https://user-images.githubusercontent.com/10561752/98488165-9a0a4300-21f5-11eb-8f8d-b4fe18d11d7a.png">
<img width="1067" alt="Screen Shot 2020-11-08 at 6 54 58 PM" src="https://user-images.githubusercontent.com/10561752/98488172-a1c9e780-21f5-11eb-9eab-244c4b17c51b.png">
