### PR TITLE
resolves issue #8

### DIFF
--- a/_data/navs/general-info.yml
+++ b/_data/navs/general-info.yml
@@ -1,7 +1,7 @@
 - name: Attend Code4Lib
   url: /general-info/attend
-- name: Venues
-  url: /general-info/venues
+#- name: Venues
+#  url: /general-info/venues
 #- name: Social Activities
 #  url: /general-info/social
 - name: Accessibility


### PR DESCRIPTION
To Test:
- Render site
- Navigate to `http://127.0.0.1:4000/general-info/attend`
- Confirm that `Venues` has been removed from the navigation in the left sidebar

Although a simple fix to remove 'venues' from the page navigation, as they're applicable for a fully virtual conference, we'll need to continue to keep an eye out for reference to venues or the 'venues' page from elsewhere on the site. 

Closes #8 