### PR TITLE
Proposed fixes for #24 and #18

### DIFF
--- a/_data/registration.yml
+++ b/_data/registration.yml
@@ -26,6 +26,11 @@ conference:
   late-cost: "$450"
   workshop-half-day-cost: "$50"
   workshop-full-day-cost: "$100"
+  # Is registration capped? true/false
+  limited-capacity:
+
+reception:
+  plus-one-cost:
 
 childcare:
   # "show" toggles the child care entry on /general-info/attend, under 'Additional Information' heading
@@ -33,5 +38,3 @@ childcare:
   full-day-cost: "$30"
   half-day-cost: "$15"
   end-date: 2020-02-08
-
-reception-plus-one-cost:

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -31,6 +31,7 @@ active: Attend Code4Lib
             </div>
         </div>
 
+        {% if site.data.registration.conference.show %}
         <div class="row">
             <div class="col-12">
                 <h3>Registration Fees</h3>
@@ -43,8 +44,8 @@ active: Attend Code4Lib
 
                     <li><span class="font-weight-bold">Pre-Conference Only</span>: {{ site.data.registration.workshop-only.half-day-cost }} per half day ({{ site.data.registration.workshop-only.full-day-cost }} for full day) {%- if site.data.registration.workshop-only.start-date -%}. Opens {{ site.data.registration.workshop-only.start-date | date: "%B %-d" }}.{%- endif -%}</li>
 
-                    {% if site.data.registration.reception-plus-one-cost %}
-                        <li><span class="font-weight-bold">Reception "plus one"</span>: {{ site.data.registration.reception-plus-one-cost }} (limit one "plus one" per registration)</li>
+                    {% if site.data.registration.reception.plus-one-cost %}
+                        <li><span class="font-weight-bold">Reception "plus one"</span>: {{ site.data.registration.reception.plus-one-cost }} (limit one "plus one" per registration)</li>
                     {% endif %}
 
                     {% if site.data.conf.venue.name != '' %}
@@ -82,55 +83,48 @@ active: Attend Code4Lib
             </div>
         </div>
 
-        <!--
-        <div class="row">
-            <div class="col-12">
-                <h2 id="health">Health & Wellness</h2>
-                <p>UPDATE: Code4Lib 2020 Conference is proceeding as planned.</p>
-                <p>The health and well-being of the Code4Lib Community is very important to us. The CDC is not currently restricting travel within the United States. However, we understand that several organizations are imposing non-essential travel restrictions and individuals are making personal choices to restrict travel.</p>
-                <p>Because of this, We are actively working with our suppliers, primarily the hotel, to see what we can do to minimize the financial impact of decreased attendance. We would like to be able to provide those that have to cancel late a partial refund, but we are not certain of the possibility at this time. We are tracking those that are not able to attend and will follow up with them as information becomes available. This follow up will likely happen after the conclusion of the event.</p>
-                <p>Additionally, please remember, Code4Lib will once again stream all of the sessions on the main conference days (not the pre-conference workshops). Some sessions may be excluded if the presenter declines to allow the session to be streamed, but it’s generally very few. You can find information about this option below, under the “Can’t attend in person?” heading.</p>
-                <p>We understand that everyone has a personal decision to make, based on your research, health, and individual situation. We support you in that decision and look forward to your participation in Code4Lib 2020, whether it be in person or remote.</p>
-                <p>We are continually monitoring the news regarding the COVID-19 (Coronavirus) situation and staying aware of the recommended guidelines from the Centers for Disease Control (CDC) and the World Health Organization (WHO). We ask that you follow the recommended safety measures as defined by these organizations. Some of which include:</p>
-                <ul>
-                    <li>Please begin preparing for your personal health at Code4Lib by acquiring alcohol-based hand-sanitizers, wipes and anything else you deem necessary to keep yourself safe during your travel time and while at Code4Lib.</li>
-                    <li>While at Code4Lib, please be sure to wash hands often or keep clean with hand-sanitizers.</li>
-                    <li>We ask that any attendees onsite who might begin to experience cold or flu-like symptoms (fever, cough, trouble breathing), to please seek medical care right away. Local emergency care facilities can be found on the Code4Lib Conduct & Safety page.</li>
-                </ul>
-                <p>For more detailed information please visit the following websites:</p>
-                <ul>
-                    <li>Centers for Disease Control: <a href="https://www.cdc.gov/coronavirus/2019-ncov/about/prevention-treatment.html">Coronavirus Prevent & Treatment</a></li>
-                    <li>World Health Organization: <a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public">Coronavirus Advice for the Public</a></li>
-                </ul>
-            </div>
-        </div>
-        -->
-
         <div class="row">
             <div class="col-12">
                 <h3>Additional Information</h3>
                 <ol>
+                    {% if site.data.registration.childcare.show %}
                     <li>
-                        Child Care is available for each day of the conference. When you register, you may select which days you require child care. The cost is $30 per full day, $15 for the half day on {{ site.data.conf.days[3].weekday }}, and $15 for child care during the {{ site.data.conf.days[1].weekday }} evening reception.
-                        {% if site.data.registration.childcare-end-date != '' %}
-                          <span class="font-weight-bold">Please Note</span>: Child Care Registration will close on {{ site.data.registration.childcare-end-date | date: "%B %e, %Y" }}. Registration and payment must be finalized on or before {{ site.data.registration.childcare-end-date | date: "%B %e"}}, to utilize the child care services.
+                        Child Care is available for each day of the conference. When you register, you may select which days you require child care. The cost is {{ site.data.registration.childcare.full-day-cost }} per full day, {{ site.data.registration.childcare.half-day-cost }} for the half day on {{ site.data.conf.days[3].weekday }}, and {{ site.data.registration.childcare.half-day-cost }} for child care during the {{ site.data.conf.days[1].weekday }} evening reception.
+                        {% if site.data.registration.childcare.end-date != '' %}
+                          <span class="font-weight-bold">Please Note</span>: Child Care Registration will close on {{ site.data.registration.childcare.end-date | date: "%B %e, %Y" }}. Registration and payment must be finalized on or before {{ site.data.registration.childcare.end-date | date: "%B %e"}}, to utilize the child care services.
                         {% endif %}
                     </li>
+                    {% endif %}
 
+                    {% if site.data.registration.conference.limited-capacity %}
                     <li>
                         Registration will close when the maximum capacity has been reached.
                         A waitlist will be available once this final round of registration is
                         closed.
                     </li>
+                    {% endif %}
+
                     <li>
-                        <span class="font-weight-bold"><a href="/talks/">Conference Talks</a></span>:
-                        See conference program <a href="/schedule/">on the schedule page</a> to get
-                        an idea of what will be part of the program. Conference speakers still need
-                        to register for the conference at full price.
+                        {% if site.data.conf.have-talks %}
+                            <span class="font-weight-bold"><a href="/talks/">Conference Talks</a></span>:
+                        {% else %}
+                            <span class="font-weight-bold">Conference Talks</span>:
+                        {% endif %}
+                        {% if site.data.conf.have-schedule %}
+                            See conference program <a href="/schedule/">on the schedule page</a> to get
+                            an idea of what will be part of the program. Conference speakers still need
+                            to register for the conference at full price.
+                        {% else %}
+                            See conference program <a href="/schedule/timeline">on the schedule page</a> to get
+                            an idea of what will be part of the program. Conference speakers still need
+                            to register for the conference at full price.
+                        {% endif %}
                     </li>
                 </ol>
             </div>
         </div>
+        {% endif %}
+
     </div>
 </section>
 


### PR DESCRIPTION
This is a fairly significant change in the behavior of the `/general-info/attend` page, to better take advantage of the variables in both `_data/conf.yml` and in `_data/registration.yml`.

#### Several additional dictionaries have been added to `_data/registration.yml`:

```
childcare:
  show: false
  full-day-cost: "$30"
  half-day-cost: "$15"
```
`show: ` toggles the display of child care information under the **Additional Information** heading

```
reception:
  plus-one-cost:
```
If `plus-one-cost:` is null, line is removed from registration costs. 

#### Using available variables to make display decisions

1. The conference `show: ` value will now toggle the display of registration info on `general-info/attend` and not just on the conference site's home page. If we don't yet have registration costs, open/close dates, etc... we can just globally disable the display of that info until we do. When `show: false`, the dates that the conference will occur will be displayed rather than the registration info.

2. The conference 'limited-capacity: ' boolean will toggle the display of information related to capped registration under the **Additional Information** heading

3. `have-talks: false` from `_data/conf.yml` will disable the hyperlinked **Conference Talks** label under the **Additional Information** heading. When false, no active link. When true, links to `/talks`. 

4. `have-schedule: false` from `_data/conf.yml` will toggle the linked 'on the schedule page' text in the **Additional Information** section between `/schedule/timeline` and `/schedule`. When `have-schedule: false`, a link to the planning committee timeline will be shown.

Closes #24
Closes #18  