### PR TITLE
reset scholarship page for 2021

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -55,6 +55,8 @@ city-state: ''
 city: ''
 state: ''
 
+# NOTE: {% if site.data.conf.venue.name != '' %} is being used to remove textual references
+#       to a physical conference venue, when the conference is fully online.
 venue:
     name: ''
     street: ''
@@ -308,8 +310,8 @@ volunteer-onsite:
 angel-fund:
     show: false
     # whether to show the "donation thermometer" & Google Spreadsheet key for it
-    thermometer: true
     # NOTE: spreadsheet needs to be "published to the web"
+    thermometer: false
     spreadsheet-key: '1IBDcAgamPKlEL-HcyfiHA6bLGf1KU8-5C1w-GN2Rze0'
     url: https://mxmerchant.com/mxcustomer/d/27881511-a676-4fa5-80cb-9987204864c4/v3
 
@@ -320,6 +322,8 @@ diversity-scholarship-applications:
   end-date: '2019-12-02'
   notification-date: '2019-12-17'
   apply-url: 'https://forms.gle/XFxkujq5HQhyac1eA'
+  committee-wiki-url: 'https://wiki.code4lib.org/Code4Lib_2021_Conference_Committees#Scholarship_Committee'
+  max-scholarship-award: '$1500'
 
 # show sponsors for diversity scholarships on general-info/scholarships
 diversity-scholarship-sponsors:

--- a/general-info/angel-fund.html
+++ b/general-info/angel-fund.html
@@ -3,7 +3,7 @@
 		<div class="col-12">
 			<h2>Diversity Scholarships Angel Fund</h2>
 			<p>
-				As part of the Code4Lib community's ongoing commitment to helping under-represented groups excel in computing and technology, we offer multiple scholarships to attend the annual conference. In addition to seeking organization sponsors for scholarships, we accept donations from individuals who would like to support the scholarship program. Individual donors will be thanked on the Scholarship page, though anonymous donation is also possible. All funds raised will help pay for transportation, accommodation, and conference registration costs for Code4Lib's Diversity Scholarships recipients for our annual conference.
+				As part of the Code4Lib community's ongoing commitment to helping under-represented groups excel in computing and technology, we offer multiple scholarships to attend the annual conference. In addition to seeking organization sponsors for scholarships, we accept donations from individuals who would like to support the scholarship program. Individual donors will be thanked on the Scholarship page, though anonymous donation is also possible. All funds raised will help pay for {% if site.data.conf.venue.name != '' %}transportation, accommodation, and {% endif %}conference registration costs for Code4Lib's Diversity Scholarships recipients for our annual conference.
 			</p>
             {% if site.data.conf.angel-fund.show %}
             <p>

--- a/general-info/scholarships.html
+++ b/general-info/scholarships.html
@@ -105,13 +105,13 @@ subnav:
        <div class="col-12">
            <h2>Accepting Applications Now!</h2>
            <p>
-               As part of Code4Lib's ongoing commitment to reducing economic barriers that prevent participation for underrepresented groups, and to achieving a balanced representation of the human experience, we are pleased to announce that we are now seeking applicants for our <a href="/general-info/scholarships">{{site.data.conf.year}} Diversity Scholarship program</a>! The <a href="https://wiki.code4lib.org/Code4Lib_2020_Conference_Committees#Scholarship_Committee">Code4Lib Scholarship Committee</a> hopes to award multiple Diversity Scholarships, based on merit and need.  Each scholarship will cover up to $1500 for travel costs, lodging, and conference fees for selected applicants to attend the <a href="/">{{site.data.conf.year}} Code4Lib Conference</a> in {{site.data.conf.location}}.
+               As part of Code4Lib's ongoing commitment to reducing economic barriers that prevent participation for underrepresented groups, and to achieving a balanced representation of the human experience, we are pleased to announce that we are now seeking applicants for our <a href="/general-info/scholarships">{{site.data.conf.year}} Diversity Scholarship program</a>! The <a href="{{ site.data.conf.committee-wiki-url }}">Code4Lib Scholarship Committee</a> hopes to award multiple Diversity Scholarships, based on merit and need.  Each scholarship will cover up to {{ site.data.conf.max-scholarship-award }} for {% if site.data.conf.venue.name != '' %}travel costs, lodging, and {% endif %}conference fees for selected applicants to attend the <a href="/">{{site.data.conf.year}} Code4Lib Conference</a>.
            </p>
            <p>
               <strong>Applications will be accepted through {{ site.data.conf.diversity-scholarship-applications.end-date | date: '%B %-d'}}{% include date_ordinals.html date=site.data.conf.diversity-scholarship-applications.end-date%}</strong> (<a href="#how-to-apply">see below for more details</a>).
            </p>
             <p>
-                The scholarship will cover conference registration and hotel accommodations up front to scholarship awardees. Other incidentals like travel and meals may be reimbursed based on the amount awarded. Reimbursement will be managed independently at the conference. Pairing up housing with other scholarship awardees or conference attendees may also be accommodated. Please contact <a href="mailto:{{site.data.conf.scholarship-contact-email}}">{{site.data.conf.scholarship-contact-email}}</a> with any questions about this arrangement. We want to ensure that financial issues do not discourage anyone from applying to this award.
+                The scholarship will cover conference registration {% if site.data.conf.venue.name != '' %}and hotel accommodations{% endif %} up front to scholarship awardees.{% if site.data.conf.venue.name != '' %} Other incidentals like travel and meals may be reimbursed based on the amount awarded. Reimbursement will be managed independently at the conference. Pairing up housing with other scholarship awardees or conference attendees may also be accommodated.{% endif %} Please contact <a href="mailto:{{site.data.conf.scholarship-contact-email}}">{{site.data.conf.scholarship-contact-email}}</a> with any questions about this arrangement. We want to ensure that financial issues do not discourage anyone from applying to this award.
             </p>
             <p>
                 We do not expect scholarship recipients to be responsible for being an ambassador for their group or an educator of others during the conference. While learning and exchange may happen as a result of interactions between participants, scholarship recipients are encouraged to focus on getting the most out of their experience and have no special duties or obligations apart from conference attendance, engaged participation to their comfort level, and giving us feedback on their experience.
@@ -155,9 +155,9 @@ subnav:
                </li>
            </ul>
 
-            <h2> Registration Details</h2>
+            <h2>Registration Details</h2>
             <p>
-                Registration spots and hotel rooms are being held for scholarship recipients. If you can attend only if you receive a scholarship, there is no need to register for the conference or book a hotel room when registration opens. Code4Lib will assist you with both registration and hotel arrangements; however, if you register for the conference or book a hotel room, you will be reimbursed along with other expenses. Reimbursement for expenses will be provided to recipients during the conference.
+                Registration spots {% if site.data.conf.venue.name != '' %}and hotel rooms {% endif %}are being held for scholarship recipients. If you can attend only if you receive a scholarship, there is no need to register for the conference {% if site.data.conf.venue.name != '' %}or book a hotel room {% endif %}when registration opens. Code4Lib will assist you with registration{% if site.data.conf.venue.name != '' %} and hotel arrangements{% endif %}; however, if you register for the conference{% if site.data.conf.venue.name != '' %} or book a hotel room{% endif %}, you will be reimbursed along with other expenses. Reimbursement for expenses will be provided to recipients during the conference.
             </p>
        </div>
    </div>
@@ -178,7 +178,7 @@ subnav:
                        <li>A brief letter of interest, no more than 500 words, which:
                            <ul>
                                <li>Identifies your eligibility for a diversity scholarship</li>
-                               <li>Describes how you see yourself benefiting from and participating in the Code4Lib {{site.data.conf.year}} conference and the general Code4Lib community </li>
+                               <li>Describes how you see yourself benefiting from and participating in the Code4Lib {{site.data.conf.year}} conference and the general Code4Lib community</li>
                            </ul>
                        </li>
                        <li>Your current resume or CV</li>


### PR DESCRIPTION
To Test:
- Build and Review [http://127.0.0.1:4000/general-info/scholarships](http://127.0.0.1:4000/general-info/scholarships)

Expect:
- All references to travel costs, local transportation, and hotel fees should be removed from the textual descriptions.
- Application status reset to 'not currently accepting applications'
- Angel fund thermometer from 2020 removed from display.

Closes #10 