### PR TITLE
show keynote proposal button

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -164,9 +164,9 @@ sponsor-btn-link: 'https://na.eventscloud.com/sponsor.c4l20'
 ###########
 
 keynote-proposals:
-  show: false
+  show: true
   submission-form: 'https://wiki.code4lib.org/2021_Keynote_Speakers_Nominations'
-  end-date: '2020-11-04'
+  end-date: '2020-11-25'
 
 workshop-proposals:
   show: false


### PR DESCRIPTION
This PR displays the button to accept keynote proposals on the conference site's landing page.

If nothing else, enabling the button will allow us to quickly check button interaction and contrasts for `:hover` events during our theming of the site. 

Closes #15 