### PR TITLE
Replace preconference w/ postconference

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -88,7 +88,7 @@ social-links:
 main-conf-email: 'code4lib@concentra-cms.com'
 sponsor-contact-email: 'code4lib.sponsorship@gmail.com'
 scholarship-contact-email: 'code4libaward@gmail.com'
-workshop-contact-email: ''
+workshop-contact-email: 'casden@email.unc.edu'
 lpc-contact-email: 'code4liblpc@gmail.com'
 accessibility-email: 'code4lib.accessibility@gmail.com'
 # when empty, community support volunteers page will use main-conf-email

--- a/_data/examples/workshop-proposals.yml
+++ b/_data/examples/workshop-proposals.yml
@@ -1,5 +1,5 @@
 - slug: 00000000001
-  preconference-title: "Workshop Descriptions are on the Ballot."
+  postconference-title: "Workshop Descriptions are on the Ballot."
   length:
   abstract: |
     Please click the Vote button to view workshop proposals and cast your vote.

--- a/_includes/proposed-js.html
+++ b/_includes/proposed-js.html
@@ -54,7 +54,7 @@
                     '<p>' + entry["{{ page.AbstractColumn }}"] + '<p>' +
                     '<h4>Proposed by: ' + presenters.join(', ') + '</h4>';
             if("{{ page.SheetsType }}" == "workshop"){
-                theHTML += '<h4>' + entry["Length/Time of Day for Preconference"] + '</h4>';
+                theHTML += '<h4>' + entry["Length/Time of Day for Postconference"] + '</h4>';
             }
             theHTML += '</div></div></div>';
             $("#list-of-talks").append(theHTML);

--- a/_includes/talks-and-workshops-buttons.html
+++ b/_includes/talks-and-workshops-buttons.html
@@ -8,7 +8,7 @@ we have talk/workshop information but don't yet know the exact schedule
             {% if site.data.conf.have-workshops %}
                 <div class="col-md-4">
                     <a href="{{ site.baseurl }}{% link workshops/index.html %}" class="btn btn-warning btn-lg">
-                        View Preconference Workshops
+                        View Postconference Workshops
                     </a>
                 </div>
             {% endif %}

--- a/childcare/index.html
+++ b/childcare/index.html
@@ -14,7 +14,7 @@ title: Childcare
 			<p>
 				We are excited to say that Code4Lib will be providing subsidized childcare for those attending the 2016 annual
 				conference in Philadelphia. This service will be provided by The Philadelphia Nanny Network and will be available
-				for all 4 days of the conference, including the pre-conference. This service was made available through generous
+				for all 4 days of the conference, including the post-conference. This service was made available through generous
 				contributions by our sponsors Equinox and Curate Camp.
 			</p>
 			<div class="row sponsor-row">

--- a/conduct/index.html
+++ b/conduct/index.html
@@ -163,7 +163,7 @@ active: 'Conduct & Safety'
                     <h2 id="officers">Community Support Volunteers</h2>
 
                     <p>
-                        During all days of the conference, including pre-conference and sponsored
+                        During all days of the conference, including post-conference and sponsored
                         evening activities, there will be Community Support Volunteers available to help provide
                         support for anyone who has been harassed, threatened, abused, or feels the
                         <a href="https://github.com/code4lib/antiharassment-policy/blob/master/code_of_conduct.md">

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -25,7 +25,7 @@ active: Attend Code4Lib
                     {% endif %}
 
                     {% if site.data.registration.workshop-only.show %}
-                        <h3>Preconference Workshops</h3>
+                        <h3>Postconference Workshops</h3>
                         <p><a class="btn btn-lg btn-warning" href="{{ site.data.registration.workshop-only.url }}">Pre Conf Registration</a></p>
                     {% endif %}
             </div>
@@ -67,7 +67,7 @@ active: Attend Code4Lib
                     When you register, you will be able to select one all-day workshop or two
                     half-day workshops. As with past Code4Lib conferences, it will be
                     possible to register for the main conference, the main conference +
-                    pre-conference day, or only for the pre-conference day (pre-conference
+                    post-conference day, or only for the post-conference day (post-conference
                     only day registration will open in mid-January).
                 </p>
 

--- a/general-info/first-timers.html
+++ b/general-info/first-timers.html
@@ -16,9 +16,9 @@ active: First Timers
 
       <h2>Conference Schedule and Structure</h2>
       <p>
-        We have a packed program with talks, preconferences, lightning talks, & breakout sessions.
+        We have a packed program with talks, postconferences, lightning talks, & breakout sessions.
 
-        The {% if site.data.conf.have-schedule %}<a href="/schedule">{% else %}<a href="/schedule/timeline">{% endif %}full conference & pre-conference schedules</a> are available on the main conference page.
+        The {% if site.data.conf.have-schedule %}<a href="/schedule">{% else %}<a href="/schedule/timeline">{% endif %}full conference & post-conference schedules</a> are available on the main conference page.
 
         The main conference is {% if site.data.conf.have-schedule %}<a href="/schedule">{% else %}<a href="/schedule/timeline">{% endif %}<strong>single track</strong></a>, meaning that you will hear the same talks as everyone else at the conference.
         This cuts down on the “fear of missing out” that you might find yourself feeling at multi-track conferences where you have to choose one session out of many that are at the same time.
@@ -69,7 +69,7 @@ active: First Timers
       {% if site.data.conf.venue.name != '' %}
       <h2>Food</h2>
       <p>
-        Morning and afternoon breaks will include snacks and caffeine. On full conference days, lunch will also be provided. No lunch or snacks will be provided on the preconference day. {% if site.data.conf.have-schedule %}<a href="/schedule">{% else %}<a href="/schedule/timeline">{% endif %}See the schedule for more details</a>
+        Morning and afternoon breaks will include snacks and caffeine. On full conference days, lunch will also be provided. No lunch or snacks will be provided on the postconference day. {% if site.data.conf.have-schedule %}<a href="/schedule">{% else %}<a href="/schedule/timeline">{% endif %}See the schedule for more details</a>
       </p>
       {% endif %}
 

--- a/general-info/propose-a-workshop.html
+++ b/general-info/propose-a-workshop.html
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Preconference Workshops
+title: Postconference Workshops
 categories: preconf
 ---
 
-<div class="container-fluid" id="preconference">
+<div class="container-fluid" id="postconference">
     <div class="row">
         <div class="col-12">
-            <h1>Proposals for Preconference Workshops</h1>
+            <h1>Proposals for Postconference Workshops</h1>
 
             {% if site.data.conf.workshop-proposals.show %}
             <a class="btn btn-warning btn-lg float-right" href="{{ site.data.conf.workshop-proposals.submission-form }}">
@@ -19,19 +19,19 @@ categories: preconf
     <div class="row">
         <div class="col-12">
             <p>
-                Pre-conferences can either be a 1-day (six hour) or a 1/2-day (three hour) session and will occur on {{ site.data.conf.days[0].weekday }}, {{ site.data.conf.days[0].date }}, {{ site.data.conf.year }}.
+                Post-conferences can be scheduled in 90 minute increments up to six hours in length and will occur on {{ site.data.conf.days.last.weekday }}, {{ site.data.conf.days.last.date }}, {{ site.data.conf.year }}.
             </p>
             <p>
-                The pre-conference sessions give folks a space to share and build
+                The post-conference sessions give folks a space to share and build
                 knowledge, as well as to teach attendees new skills relevant to library
-                technology. Pre-conference sessions can range from workshops to working
+                technology. Post-conference sessions can range from workshops to working
                 sessions. We welcome a variety of ideas and encourage submissions from
                 first-time presenters and members of groups not well-represented within the
                 Code4Lib community, including but not limited to: women, people of color,
                 people with disabilities, LGBT+.
             </p>
             <p>
-                If you're looking for inspiration, there are many great examples of pre-conferences from previous years.
+                If you're looking for inspiration, there are many great examples of post-conferences from previous years.
                 {% assign lastyear =  site.data.conf.year | minus: 1 %}
                 <ul>{% for year in (2016..lastyear) reversed %}
                     <li><a href="http://{{year}}.code4lib.org/workshops/">{{year}} Conference</a></li>

--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -34,7 +34,7 @@ published: true
 
                 <h2>About the Conference</h2>
                 <p>
-                  Each year, the Code4Lib conference helps revitalize the community as participants meet in person to discuss new and ongoing projects in a single-track format with short presentations and talks. It also provides in-depth participatory learning experiences through its volunteer-led pre-conference programs, and offers ad-hoc breakout sessions focused on collaboration around topics of interest.
+                  Each year, the Code4Lib conference helps revitalize the community as participants meet in person to discuss new and ongoing projects in a single-track format with short presentations and talks. It also provides in-depth participatory learning experiences through its volunteer-led post-conference programs, and offers ad-hoc breakout sessions focused on collaboration around topics of interest.
                   <ul>
                     <li>Conference speakers and programs are chosen by a voting process open to the entire community.</li>
                     <li>Sessions are live-streamed to support remote attendance. Beginning in 2016, the stream was captioned in real-time to promote accessibility, and the community is committed to continuing this service.</li>

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -16,13 +16,13 @@ title: Schedule
             <h3>9AM to 5PM</h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
-            <h3><a href="/workshops">Preconference Workshops</a></h3>
+            <h3><a href="/workshops">Postconference Workshops</a></h3>
             <p>
-                Preconference details are available
+                Postconference details are available
                 {% if site.data.registration.workshop-only.url.size > 0 %}
                     on the <a href="{{site.data.registration.workshop-only.url}}">registration site</a> and
                 {% endif %}
-                on the <a href="/workshops">Preconference Workshops</a> page.
+                on the <a href="/workshops">Postconference Workshops</a> page.
             </p>
         </div>
     </div>

--- a/workshops/index.html
+++ b/workshops/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Preconference Workshops
+title: Postconference Workshops
 ---
 
 <div class="container">

--- a/workshops/proposed-workshops.html
+++ b/workshops/proposed-workshops.html
@@ -7,7 +7,7 @@ title: Proposed Workshops
     <div class="row">
 
         <div class="col-12 col-sm-8">
-            <h3>Proposed Preconference Workshops</h3>
+            <h3>Proposed Postconference Workshops</h3>
         </div>
         <div class="col-12 col-sm-4">
             {% if site.data.conf.workshop-voting.show %}
@@ -20,7 +20,7 @@ title: Proposed Workshops
                 <div class="card-header" role="tab" id="{{ shop.slug }}Header">
                     <h4 class="card-title">
                         <a role="button" data-toggle="collapse" data-parent="#list-of-talks" href="#{{ shop.slug }}" aria-expanded="true" aria-controls="{{ shop.slug }}">
-                            {{ shop.preconference-title }}
+                            {{ shop.postconference-title }}
                         </a>
                     </h4>
                 </div>


### PR DESCRIPTION
This PR finds instances of `pre-conference`, `Pre-conference`, or `preconference` and replaces them with `post-conference`, `Post-conference`, or `Postconference`, respectively.

I've intentionally avoided any file references with an underscore, e.g. `post_conference`, as those appear to be used for setting the modes of the site: pre, peri, post.

Although there are elements with an attribute of `class="preconference"`, I did not find a corresponding CSS rule for `.preconference`; thus, I've updated the class name to `postconference`. 

Closes #34