### PR TITLE
add reference to online conference

### DIFF
--- a/_includes/homepage/jumbotron.html
+++ b/_includes/homepage/jumbotron.html
@@ -13,7 +13,11 @@
                 <h1 class="text-right">
                     <span class="sr-only">code for lib {{site.data.conf.year}}</span>
                     {{site.data.conf.location}}
+                    {% if site.data.conf.venue.name != '' %}
                     <small>{{site.data.conf.days[0].date-data | date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}} {{site.data.conf.year}}</small>
+                    {% else %}
+                    <small>{{site.data.conf.days[0].date-data | date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}} &#8226; Online</small>
+                    {% endif %}
                 </h1>
 
                 <div id="conferenceActions">


### PR DESCRIPTION
This PR adds some logic to `div#conferenceInfo`. If `venue.name` in `_data/conf.yml` is `''`, display conference as online in main conference info section.

<img width="602" alt="Screen Shot 2020-11-25 at 7 22 53 AM" src="https://user-images.githubusercontent.com/10561752/100227462-2fdce800-2eef-11eb-9ce9-ccab2116c18a.png">

Close #56 