### PR TITLE
requested updates for kathy azevedo

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -306,6 +306,10 @@ volunteer-onsite:
 # Scholarships
 ################
 
+criteria:
+  # if you have this year's eligibility requirements, show criteria section on general-info/scholarships
+  show: false
+
 angel-fund:
     show: false
     # whether to show the "donation thermometer" & Google Spreadsheet key for it

--- a/general-info/angel-fund.html
+++ b/general-info/angel-fund.html
@@ -1,9 +1,9 @@
 <div class="container-fluid" id="angel-fund">
 	<div class="row">
 		<div class="col-12">
-			<h2>Diversity Scholarships Angel Fund</h2>
+			<h2>Individual Giving</h2>
 			<p>
-				As part of the Code4Lib community's ongoing commitment to helping under-represented groups excel in computing and technology, we offer multiple scholarships to attend the annual conference. In addition to seeking organization sponsors for scholarships, we accept donations from individuals who would like to support the scholarship program. Individual donors will be thanked on the Scholarship page, though anonymous donation is also possible. All funds raised will help pay for {% if site.data.conf.venue.name != '' %}transportation, accommodation, and {% endif %}conference registration costs for Code4Lib's Diversity Scholarships recipients for our annual conference.
+				The Code4Lib community understands that this year has brought financial hardship to many of us. To help ease the financial burden and encourage broad participation, we're offering multiple scholarships to attend the annual conference. In addition to seeking organization sponsors for scholarships, we accept donations from individuals who would like to support the scholarship program. Individual donors will be thanked on the Scholarship page, though anonymous donation is also possible. All funds raised will go towards conference registration costs for Code4Lib's scholarship recipients.
 			</p>
             {% if site.data.conf.angel-fund.show %}
             <p>
@@ -16,6 +16,7 @@
 
 			<div id="donation-total"></div>
 
+			<!--
 			<div class="row">
 				<p class="col-md-8 js-matching-funds">
 					Matching Funds are a great way to raise Diversity Scholarship funds and to double your donation’s impact! The organization(s) listed below have generously pledged to match your donations once a Matching Fund goal is reached.
@@ -26,6 +27,7 @@
 					</a>
 				</div>
 			</div>
+			-->
 
 			{% if site.data.conf.angel-fund.thermometer %}
 				<div id="donation-thermometers"></div>

--- a/general-info/scholarships.html
+++ b/general-info/scholarships.html
@@ -143,6 +143,7 @@ subnav:
        <div class="col-12">
            <a name="criteria"></a>
            <h2>Eligibility, Criteria, And Requirements</h2>
+           {% if site.data.conf.criteria.show %}
            <ul>
                <li>
                An applicant must be a member of a group not well-represented within the code4lib community, including but not limited to: women, people of color, LGBTQ+, ability/disability, non-binary gender identities, etc. We also invite applications from members of underrepresented and/or marginalized groups that don't fit into the categories listed above.
@@ -154,10 +155,15 @@ subnav:
                The scholarship recipients will be selected based upon their merit and financial needs.
                </li>
            </ul>
+           {% else %}
+           <p>
+               More information to come
+           </p>
+           {% endif %}
 
             <h2>Registration Details</h2>
             <p>
-                Registration spots {% if site.data.conf.venue.name != '' %}and hotel rooms {% endif %}are being held for scholarship recipients. If you can attend only if you receive a scholarship, there is no need to register for the conference {% if site.data.conf.venue.name != '' %}or book a hotel room {% endif %}when registration opens. Code4Lib will assist you with registration{% if site.data.conf.venue.name != '' %} and hotel arrangements{% endif %}; however, if you register for the conference{% if site.data.conf.venue.name != '' %} or book a hotel room{% endif %}, you will be reimbursed along with other expenses. Reimbursement for expenses will be provided to recipients during the conference.
+                Registration spots {% if site.data.conf.venue.name != '' %}and hotel rooms {% endif %}are being held for scholarship recipients. If you can attend only if you receive a scholarship, there is no need to register for the conference {% if site.data.conf.venue.name != '' %}or book a hotel room {% endif %}when registration opens. Code4Lib will assist you with registration{% if site.data.conf.venue.name != '' %} and hotel arrangements{% endif %}; however, if you register for the conference{% if site.data.conf.venue.name != '' %} or book a hotel room{% endif %}, you will be reimbursed. Reimbursement for expenses will be provided to recipients during the conference.
             </p>
        </div>
    </div>
@@ -195,7 +201,7 @@ subnav:
                </p>
            {% else %}
                <p>
-                   Applications for diversity scholarships are not currently being collected. When we are accepting applications, this site will detail what is required.
+                   Applications for scholarship are not currently being collected. When we are accepting applications, this site will detail what is required.
                </p>
            {% endif %}
        </div>
@@ -203,4 +209,5 @@ subnav:
 </div>
 
 {% include_relative angel-fund.html %}
+
 </section>


### PR DESCRIPTION
This PR contains several tweaks to the information presented on the scholarship page of the conference site.
- A new variable in `_data/conf.yml` toggles the display of scholarship eligibility requirement. If `show: false`, the website will display "More information to come".
- 'Diversity Scholarship Angel Fund' heading updated to read 'Individual Giving' and specific references to diversity have been removed from the text, as this year's giving will focus on financial hardship
- Takes a first stab at rewriting the text from the perspective of financial hardship
> The Code4Lib community understands that this year has brought financial hardship to many of us. To help ease the financial burden and encourage broad participation, we're offering multiple scholarships to attend the annual conference. In addition to seeking organization sponsors for scholarships, we accept donations from individuals who would like to support the scholarship program. Individual donors will be thanked on the Scholarship page, though anonymous donation is also possible. All funds raised will go towards conference registration costs for Code4Lib's scholarship recipients.