### PR TITLE
fix link hover state on postconference page

### DIFF
--- a/assets/_scss/_links.scss
+++ b/assets/_scss/_links.scss
@@ -10,3 +10,7 @@
   border-bottom: 2px solid;
   text-decoration: none;
 }
+
+#postconference a:hover {
+    color: lighten(#00D5C0, 10%);
+}


### PR DESCRIPTION
To test:
- All links on `http://127.0.0.1:4000/general-info/propose-a-workshop.html` should be presented as turquoise and lighten by 10% when hovered