### PR TITLE
enable t-shirt logo proposals

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -188,9 +188,9 @@ poster-proposals:
   end-date: '2020-12-06'
 
 shirt-proposals:
-  show: false
-  submission-form: 'https://wiki.code4lib.org/2019_Code4Lib_T-Shirt_Design_Competition'
-  end-date: '2020-11-15'
+  show: true
+  submission-form: 'https://docs.google.com/forms/d/e/1FAIpQLSczoRX5Rd37TIWT9MhZJxS1hR7V3UQu0aU93rzhF8jY8as1KQ/viewform?usp=sf_link'
+  end-date: '2021-01-06'
 
 host-proposals:
   show: false


### PR DESCRIPTION
This PR enables a button on the homepage to submit t-shirt proposals for this year.

closes #81 