### PR TITLE
Issue 74 - Button text for Volunteer

### DIFF
--- a/_includes/homepage/pre_conference.html
+++ b/_includes/homepage/pre_conference.html
@@ -229,7 +229,7 @@
                     title='Conference Committees'
                     end-date=site.data.conf.volunteer-committee.end-date
                     url=site.data.conf.volunteer-committee.url
-                    url-text='Sign up'
+                    url-text='Volunteer for Committee'
                 %}
             {% endif %}
             {% if site.data.conf.volunteer-dutyoff.show %}
@@ -237,7 +237,7 @@
                     title='Community Support Volunteers'
                     end-date=site.data.conf.volunteer-dutyoff.end-date
                     url=site.data.conf.volunteer-dutyoff.url
-                    url-text='Sign up'
+                    url-text='Volunteer for Community Support'
                 %}
             {% endif %}
             {% if site.data.conf.volunteer-onsite.show %}
@@ -245,7 +245,7 @@
                     title='Volunteer at Code4Lib'
                     end-date=site.data.conf.volunteer-onsite.end-date
                     url=site.data.conf.volunteer-onsite.url
-                    url-text='Volunteer for Committee'
+                    url-text='Volunteer for Onsite Conference'
                 %}
             {% endif %}
         </div>

--- a/_includes/homepage/pre_conference.html
+++ b/_includes/homepage/pre_conference.html
@@ -245,7 +245,7 @@
                     title='Volunteer at Code4Lib'
                     end-date=site.data.conf.volunteer-onsite.end-date
                     url=site.data.conf.volunteer-onsite.url
-                    url-text='Sign up'
+                    url-text='Volunteer for Committee'
                 %}
             {% endif %}
         </div>


### PR DESCRIPTION
Rename button text for volunteer per Issue #74. New text:
- for conference committee: Volunteer for Committee
- for on-duty support: Volunteer for Community Support 
- for onsite: Volunteer for Onsite conference (we might not need this, but might as well fix it.)