### PR TITLE
Fixes Show/Hide Toggling of Speaker Info

### DIFF
--- a/_includes/speaker_box.html
+++ b/_includes/speaker_box.html
@@ -2,9 +2,7 @@
 
 <div class="speaker-box text-center" id="{{ speaker.id }}-id" data-speaker-info="#{{ speaker.id }}-info">
     <div class="speaker-box-inner">
-        <a href="#" class="speaker-info-toggle" data-target="#{{ speaker.id }}" aria-expanded="false" aria-controls="{{ speaker.id }}">
             <img class="clip-circle-lg" src="{{ speaker.image_src | relative_url }}" alt="{{ speaker.name }}">
-        </a>
         <h2 class="h4 speaker-name"><a href="#" class="speaker-info-toggle" data-target="#{{ speaker.id }}" aria-expanded="false" aria-controls="{{ speaker.id }}">{{ speaker.name }}</a></h2>
         <div class="speaker-mini">
             <p class="speaker-title">{{ speaker.work_title }}</p>

--- a/assets/_scss/_speakers.scss
+++ b/assets/_scss/_speakers.scss
@@ -103,12 +103,12 @@ p.speaker-inst {
 }
 
 .speaker-info.show {
-  -moz-transition: max-height .35s ease;
-  -o-transition: max-height .35s ease;
-  -webkit-transition: max-height .35s ease;
+  -moz-transition: max-height .15s ease;
+  -o-transition: max-height .15s ease;
+  -webkit-transition: max-height .15s ease;
   max-height: 600px;
-  transition: max-height .35s ease;
-  transition-delay: .15s;
+  transition: max-height .15s ease;
+  transition-delay: .0s;
 }
 
 .speaker-info-inner {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -73,18 +73,7 @@ jQuery(document).ready(function($){
     }
 
     function toggleSpeaker(target){
-        var shownHeight;
-
-        if ($('.speaker-info.show').length){
-            shownHeight = $('.speaker-info.show').height();
-        } else {
-            shownHeight = 0;
-        }
-
-        $('html, body').animate({
-            scrollTop: $(target+'-id').offset().top - shownHeight
-        }, 500);
-        if (!$(target+'-id').hasClass('show')){
+        if (!$(target+'-id').hasClass('selected')){
                 $('.speaker-info').removeClass('show');
                 $('.speaker-box').removeClass('selected');
                 $(target+'-info').addClass('show');


### PR DESCRIPTION
Previously, clicking a speaker's name would reveal biographical details, but there was no method to close an opened info box. This PR enables clicking the speaker name to show and hide the biographical details.

![Dec-13-2020 18-29-26](https://user-images.githubusercontent.com/10561752/102027484-641b2a00-3d72-11eb-92b9-b35b11554c2c.gif)

Closes #75 & #76 
