### PR TITLE
Prospectus 2021 typo fix

### DIFF
--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -66,7 +66,7 @@ published: true
 
                 {% if site.data.conf.sponsor-contact-email != "" %}
                 <p>
-                    If you're ready to make a pledge please <a href="{{site.data.conf.sponsor-btn-link}}">visit our sponsor registration form</a>. If you have questions, please get in touch with <a href="mailto:{{site.data.conf.sponsor-contact-email}}">{{site.data.conf.sponsor-contact-email}}</a>.
+                    If you're ready to make a pledge, please <a href="{{site.data.conf.sponsor-btn-link}}">visit our sponsor registration form</a>. If you have questions, please get in touch with <a href="mailto:{{site.data.conf.sponsor-contact-email}}">{{site.data.conf.sponsor-contact-email}}</a>.
                 </p>
                 {% endif %}
 
@@ -200,7 +200,7 @@ published: true
                         <use class="sponsor-badge" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#thumbs-badge"></use>
                     </svg>
                     <h3>Supporter</h3>
-                    <p><strong>$250 - $749</strong></p>
+                    <p><strong>$300 - $749</strong></p>
                     <ul>
                         <li>Small logo on the conference website as Supporter Sponsor</li>
                         <li>Small logo on the Conference "Screensaver" as displayed throughout conference</li>


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mary.jinglewski@gmail.com>

This PR fixes the number amount associated with the Supporter level sponsorship on the Prospectus. (The irony of your branch name, which fixes copyediting/details, having a typo.)