### PR TITLE
Add skip link

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,3 +1,4 @@
+<a href="#main" class="sr-only sr-only-focusable">Skip to main content</a>
 <nav class="navbar navbar-expand-md navbar-dark" role="navigation" style="background: black;">
   <!-- <div class="container-fluid"> -->
     <!-- Brand and toggle get grouped for better mobile display -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,6 @@
 {% include header.html %}
 {% include search_results.html %}
-
+<div id="main" class="content">
 {{ content }}
-
+</div>
 {% include footer.html %}

--- a/_layouts/secondary-nav.html
+++ b/_layouts/secondary-nav.html
@@ -33,7 +33,7 @@
                     </ul>
                 </nav>
             </div>
-            <div class="col-12 col-md-9 col-lg-10">
+            <div id="main" class="col-12 col-md-9 col-lg-10">
                 {{ content }}
             </div>
         </div>


### PR DESCRIPTION
Fixes issue #71 

How to test:

Accessibility:
- Load any page (suggest testing a subpage, the homepage, and any pages that do not load the nav.)
- Press tab
- Skip link should appear
- When selected, link should give focus to main content of page

Javascript:
- No JS functionality should be lost (I changed the id name of the main div from "main" to "content". I didn't see any references to it using 'grep -r "#main" . ' but this might be good to check before merging.