### PR TITLE
Issue73

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -104,7 +104,7 @@ anonymous-form: 'https://css4csv.clir.org/anonymous-incident-report-form/'
 # - post:   for after the conference is over (TODO: we never made this template!)
 #
 ####################
-homepage-display: peri
+homepage-display: pre
 
 livestream:
   show: false

--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -104,7 +104,7 @@ anonymous-form: 'https://css4csv.clir.org/anonymous-incident-report-form/'
 # - post:   for after the conference is over (TODO: we never made this template!)
 #
 ####################
-homepage-display: pre
+homepage-display: peri
 
 livestream:
   show: false
@@ -123,21 +123,21 @@ closed-captioning:
 # Peri display descriptions and titles
 peri:
   day1-am-title: "Conference, Day 1"
-  day1-am-desc: "Keynote #1 kicks off the conference then talks until 5"
-  day1-pm-title: "Reception"
-  day1-pm-desc: "Join us for the reception at the Carnegie Museum of Pittsburgh"
+  day1-am-desc: "Keynote"
+  day1-pm-title: "Reception?"
+  day1-pm-desc: "Join us"
   day2-am-title: "Conference, Day 2"
-  day2-am-desc: "Talks until 5"
+  day2-am-desc: "Awesome Talks"
   day2-pm-title: "Game Night"
-  day2-pm-desc: "Come join fellow code4libers in a few board or card games"
+  day2-pm-desc: "Board or card games"
   day3-am-title: "Conference, Day 3"
-  day3-am-desc: "Talks until 5"
+  day3-am-desc: "Awesome Talks"
   day3-pm-title: "Social Event"
   day3-pm-desc: "Lots of folks having fun"
   day4-am-title: "Conference, Day 4"
-  day4-am-desc: "Talks until 5"
-  day4-pm-title: "Newcomer Dinner"
-  day4-pm-desc: "It is a Code4Lib tradition to welcome those who are new to the conference"
+  day4-am-desc: "Awesome Talks"
+  day4-pm-title: "Hackathon"
+  day4-pm-desc: "Let's do this"
   day5-am-title: "Conference, Day 5"
   day5-am-desc: "Workshops"
 

--- a/_includes/homepage/going_on_block.html
+++ b/_includes/homepage/going_on_block.html
@@ -1,9 +1,9 @@
 <div class="row going-on">
     <div class="col-12 col-sm-6 col-md-5">
         {% if include.primary %}
-        <h2 class="h3">{{ include.title }}</h2>
+        <div class="h4">{{ include.title }}</div>
         {% else %}
-        <h2 class"h5">{{ include.title }}</h2>
+        <div class="h4">{{ include.title }}</div>
         {% endif %}
         {% if include.more-info-link.size %}
             <a href="{{ include.more-info-link }}">

--- a/_includes/homepage/pre_conference.html
+++ b/_includes/homepage/pre_conference.html
@@ -1,4 +1,9 @@
 <div class="col-12">
+
+    <!-- Registation -->
+    <div class="row expo-row">
+        <div class="col-12">
+            <h3 class="expo">Registration</h3>
     {% comment %} details known/announced but can't register yet {% endcomment %}
     {% if site.data.registration.conference.show
     and site.data.registration.conference.open == false %}
@@ -26,11 +31,16 @@
         %}
     {% endif %}
 
+            </div>
+        </div>
+
+
+
     <!-- Voting -->
     {% if site.data.conf.keynote-voting.show or site.data.conf.talk-voting.show or site.data.conf.panel-voting.show or site.data.conf.workshop-voting.show or site.data.conf.shirt-voting.show or site.data.conf.poster-voting.show %}
     <div class="row">
         <div class="col-12">
-            <h4 class="expo">Voting</h4>
+            <h3 class="expo">Voting</h3>
 
             <!-- Keynote -->
             {% if site.data.conf.keynote-voting.show %}
@@ -109,7 +119,7 @@
     {% if site.data.conf.talk-proposals.show or site.data.conf.poster-proposals.show or site.data.conf.panel-proposals.show or site.data.conf.workshop-proposals.show or site.data.conf.shirt-proposals.show or site.data.conf.host-proposals.show or site.data.conf.keynote-proposals.show %}
     <div class="row">
         <div class="col-12">
-            <h4 class="expo">Proposals</h4>
+            <h3 class="expo">Proposals</h3>
 
 
             <!-- Keynotes -->
@@ -200,7 +210,7 @@
     {% if site.data.conf.diversity-scholarship-applications.show  %}
     <div class="row">
         <div class="col-12">
-            <h4 class="expo">Announcements</h4>
+            <h3 class="expo">Announcements</h3>
 
             <!-- Scholarships -->
             {% if site.data.conf.diversity-scholarship-applications.show %}
@@ -223,7 +233,7 @@
         or site.data.conf.volunteer-onsite.show %}
     <div class="row">
         <div class="col-12">
-            <h4 class="expo">Volunteering</h4>
+            <h3 class="expo">Volunteering</h3>
             {% if site.data.conf.volunteer-committee.show %}
                 {% include homepage/going_on_block.html
                     title='Conference Committees'
@@ -257,14 +267,3 @@
 {% if site.data.conf.show-sponsors %}
     {% include homepage/sponsor_block.html %}
 {% endif %}
-
-{% comment %}
-<div class="col-12">
-    <h3>Conference Hotel</h3>
-
-    <div class="row">
-        <p class="col-sm-4"><img class="img-fluid" src="/assets/img/venues/doubletree.jpg" alt="DoubleTree San Jose"></p>
-        <p class="col-sm-8">We've negotiated rooms at the San Jose DoubleTree by Hilton. Conveniently located near the San Jose International Airport, the DoubleTree is a great location. It includes an on-site restaurant and sushi bar, coffee shops, WiFi (included in our room rate), and a pool plus hot tub area. The hotel is a short ten-minute drive from downtown San Jose with access to public transit as well. <strong><a href="/general-info/venues">See more details on the Venues page</a></strong>.</p>
-    </div>
-</div>
-{% endcomment %}

--- a/assets/_scss/_global.scss
+++ b/assets/_scss/_global.scss
@@ -30,13 +30,13 @@ h4,
 h5 {
   font-family: $font-family-sans-serif;
   letter-spacing: .02em;
-
-  &.expo {
-    border-bottom: 1px solid $crayola-pink;
-  }
-
   margin-top: $font-size-base;
   margin-bottom: $font-size-base;
+}
+
+.expo {
+    border-bottom: 1px solid $crayola-pink;
+    margin-bottom: $font-size-base;
 }
 
 .btn:focus {

--- a/assets/_scss/_goingon.scss
+++ b/assets/_scss/_goingon.scss
@@ -5,6 +5,7 @@
 
 .going-on {
   margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 .going-on h2,


### PR DESCRIPTION
Adjusts heading element order for `pre` and `peri` settings of the homepage in `_data/conf.yml`. Below are screencaps from Wave of the new heading order.


**SITE SET TO `pre`**

<img width="403" alt="pre" src="https://user-images.githubusercontent.com/10561752/103462923-ac38c700-4cf6-11eb-9db2-723f273822ea.png">


**SITE SET TO `peri`**

<img width="454" alt="peri" src="https://user-images.githubusercontent.com/10561752/103462932-b955b600-4cf6-11eb-8b09-904137654367.png">


Closes #73 