### PR TITLE
Adds Financial Assistance Link

### DIFF
--- a/general-info/financial-assistance.html
+++ b/general-info/financial-assistance.html
@@ -219,7 +219,9 @@ subnav:
 		</div>
         <p>Every year we have seen the Code4Lib Community gather together to support diversity and inclusion with the Diversity Scholarships. Due to the ups and downs of the past year, we have chosen to direct our financial support to those experiencing financial hardships.</p>
         <p>We understand that budgets have been cut around the world and many individuals are experiencing transitions that may cause financial hardships. We strive to make Code4Lib accessible to all that want to attend. If you are interested in participating this year, but are challenged by the registration fee, please complete the Financial Assistance Form to request financial assistance.</p>
-        <p>Financial Assistance Form will be linked here once registration opens.</p>
+        <div class="font-weight-bold" style="padding-bottom: 20px;">
+            <a href="https://na.eventscloud.com/esurvey/c4lfinaid" target="_blank">Click here to access the Financial Assistance Form</a>
+        </div>
     </div>
 </div>
 </div>


### PR DESCRIPTION
Just above the Individual Giving section, a link to the form should be visible on the following page: http://127.0.0.1:4000/general-info/financial-assistance

Closes #117 