### PR TITLE
Peri theming

### DIFF
--- a/assets/_scss/_homepage-events.scss
+++ b/assets/_scss/_homepage-events.scss
@@ -12,7 +12,7 @@
 }
 
 .event-card {
-  background: $white;
+  background: $card-bg;
   border-radius: 5px;
   box-shadow: 3px 3px 9px rgba(0, 0, 0, .2);
   box-sizing: border-box;
@@ -31,9 +31,9 @@
     border-radius: 50%;
     box-sizing: border-box;
     max-width: 100px;
-    background: $white;
-    --primary-color: #{$sponsor-badge-primary};
-    --background-color: $white;
+    background: $day-night-icon-bg;
+    --primary-color: #{$day-event-icon-color};
+    --background-color: #{$night-event};
   }
 
   %card-content {
@@ -42,7 +42,7 @@
 
   .card-toolbar {
     @extend %card-content;
-    background: $day-event;
+    border-bottom: 2px solid $day-event-cap;
     color: $white;
     height: 3em;
 
@@ -62,7 +62,8 @@
     }
 
     &.night {
-      background: $night-event;
+      border-color: $night-event;
+      --primary-color: #{$night-event};
     }
   }
 
@@ -77,9 +78,13 @@
     }
 
     p {
-      color: #a1a1a1;
+      color: $text-color-subtle;
       margin: 0;
       line-height: initial;
     }
+    a {
+      color: $text-color;
+      text-decoration: underline;
+    }    
   }
 }

--- a/assets/_scss/_schedule.scss
+++ b/assets/_scss/_schedule.scss
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 .sched-well {
-  background-color: $cultured-white;
-  color: $speaker-info-color;
+  background-color: $card-bg;
+  color: $gray-400;
   border-radius: 10px;
   box-shadow: 4px 5px 0px rgba(0, 0, 0, .11);
   margin-bottom: 20px;
@@ -37,6 +37,7 @@
 
 .text-right h3 {
   font-size: 1.25em;
+  color: $gray-400;
 
 }
 

--- a/assets/_scss/_schedule.scss
+++ b/assets/_scss/_schedule.scss
@@ -19,7 +19,7 @@
 
 .sched-well a {
   //@include link-styles;
-  color: #ea1cdd !important;
+  color: #EE44E2 !important;
 
   &:active,
   &:focus,

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -160,9 +160,13 @@ $jumbotron-btn-color:     $gray-lighter;
 $jumbotron-btn-hover:     darken($primary-dark, 6.5%);
 
 // Event cards
-$day-event:               $accent-light;
-$night-event:             $primary-dark;
-
+$card-bg:                 $oxford-blue-desat;
+$event-card-color:        $cultured-white;
+$day-event-cap:           $honey-yellow;
+$day-event-icon-color:    darken($honey-yellow, 6.5%);
+$night-event:             $turquoise;
+$day-night-icon-bg:       $card-bg;
+$schedule-card-title:     $crayola-pink-desat;
 //== Scaffolding
 //
 //## Settings for some of the most global styles.
@@ -171,6 +175,7 @@ $night-event:             $primary-dark;
 $body-bg:               $oxford-blue !default;
 //** Global text color on `<body>`.
 $text-color:            $cultured-white !default;
+$text-color-subtle:     #ccc; 
 
 //** Global textual link color.
 $link-color:            $turquoise !default;

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -7,6 +7,7 @@ $bootstrap-sass-asset-helper: true !default;
 // Background
 $oxford-blue: #060c40;
 $xiketic: #070413;
+$oxford-blue-desat: #0D1661;
 
 // Foreground
 $cultured-white: #F5F5F5;
@@ -19,7 +20,7 @@ $cultured-white-lighter: #FFF;
 $turquoise-lighter: lighten($turquoise, 10%);
 $crayola-pink-lighter: lighten($crayola-pink, 10%);
 $honey-yellow-lighter: lighten($honey-yellow, 10%);
-
+$crayola-pink-desat: #EE44E2;
 // Buttons
 $btn-bg-color-mid: $honey-yellow;
 $btn-color-mid: #000;


### PR DESCRIPTION
Addresses issue #101  - Catching up with theming post-Whova integration.

Schedule page
![Screenshot_2021-01-27 Schedule](https://user-images.githubusercontent.com/10285039/106083122-f476b980-60e9-11eb-9d4b-f10a9c80e748.png)

Also in this PR:

Homepage with schedule in peri state with day/night icons (still in progress...)
<img width="1187" alt="Homepage in peri state with day/night area" src="https://user-images.githubusercontent.com/10285039/106082859-7b776200-60e9-11eb-8af6-2885aa9e1b28.png">


Completely superfluous note:
I've found that [Material Design Dark theme](https://material.io/design/color/dark-theme.html#properties) is a good resource on understanding how to make a better dark theme. Makes sense to consult this since there are design elements on the site that were very clearly influenced by this.
