### PR TITLE
modify tabindex value on selected speaker change

### DIFF
--- a/_includes/speaker_box.html
+++ b/_includes/speaker_box.html
@@ -43,7 +43,7 @@
             {% for shop in workshops  %}
                 {% for speaker_id in shop.speakers %}
                     {% if speaker_id == speaker.id %}
-                    <p class="speaker-session">Workshop: <a href="{{ shop.url }}">{{ shop.title }}</a></p>
+                    <p class="speaker-session">Workshop: <a href="{{ shop.url }}" tabindex="-1">{{ shop.title }}</a></p>
                     {% endif %}
                 {% endfor %}
             {% endfor %}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -72,12 +72,36 @@ jQuery(document).ready(function($){
         }, 300);
     }
 
+//    function toggleSpeaker(target){
+//        if (!$(target+'-id').hasClass('selected')){
+//                $('.speaker-info').removeClass('show');
+//                $('.speaker-box').removeClass('selected');
+//                $(target+'-info').addClass('show');
+//                $(target+'-id').addClass('selected');
+//            } else {
+//                $(target+'-info').removeClass('show');
+//                $(target+'-id').removeClass('selected');
+//            }
+//    }
+
     function toggleSpeaker(target){
-        if (!$(target+'-id').hasClass('selected')){
+        var shownHeight;
+
+        if ($('.speaker-info.show').length){
+            shownHeight = $('.speaker-info.show').height();
+        } else {
+            shownHeight = 0;
+        }
+
+        $('html, body').animate({
+            scrollTop: $(target+'-id').offset().top - shownHeight
+        }, 500);
+        if (!$(target+'-id').hasClass('show')){
                 $('.speaker-info').removeClass('show');
                 $('.speaker-box').removeClass('selected');
                 $(target+'-info').addClass('show');
                 $(target+'-id').addClass('selected');
+                $(target+'-id + div.speaker-info a' ).attr('tabindex', '0');
             } else {
                 $(target+'-info').removeClass('show');
                 $(target+'-id').removeClass('selected');


### PR DESCRIPTION
`a` elements in speaker information boxes are loaded with a tabindex of `-1`.

When a speaker is `.selected`, the tabindex of all `a` elements in that speaker's information box are changed to a tabindex of `0`. This will allow traversal of speakers via the tab key, without a screenreader speaking the workshop titles for non-selected speakers.

Closes #79 