### PR TITLE
takes keyboard focus off duplicate link in schedule card

### DIFF
--- a/_includes/homepage/event_card.html
+++ b/_includes/homepage/event_card.html
@@ -1,6 +1,6 @@
 <div class="event-card">
     <div class="card-toolbar {% if include.icon == 'pm' %}night{% endif %}">
-        <a href="{{ include.link }}" aria-label="{{ include.title }}">
+        <a href="{{ include.link }}" tabindex="-1" aria-label="{{ include.title }}">
             {% if include.icon == 'am' %}
             <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" class="img-avatar" alt="day">
                 <path style="fill: var(--primary-color);" d="M6.76 4.84l-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91l-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7l1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91l1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z"/>


### PR DESCRIPTION
for solving issue #177 

I added `tabindex="-1"` to the link including the svg icons so tab order will go from header to header and skip the icons (yet the icons can still be clicked via mouse).

Other options include taking link off the svg or wrapping the whole card in a link (though this can muck with the ability to copy text within the block)