### PR TITLE
Enable 'join live' in hero

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -106,14 +106,15 @@ anonymous-form: 'https://css4csv.clir.org/anonymous-incident-report-form/'
 # - post:   for after the conference is over (TODO: we never made this template!)
 #
 ####################
-homepage-display: pre
+homepage-display: peri
 
 livestream:
-  show: false
-  url: 'https://www.youtube.com/c/code4lib/live'
+  show: true
+  button-label: "Registered? Join Live"
+  url: 'https://whova.com/portal/webapp/codel_202103/'
 
 slides:
-  show: true
+  show: false
   url: 'https://osf.io/meetings/c4l21/'
   contact: ''
   email: ''
@@ -152,8 +153,8 @@ show-sponsors: true
 # If true, any "Sponsors" links will go to /prospectus instead of /sponsors
 call-for-sponsors: false
 # Individual Page Buttons
-homepage-sponsor-button: true
-sponsorpage-sponsor-button: true
+homepage-sponsor-button: false
+sponsorpage-sponsor-button: false
 # URL to document
 prospectus-document: ''
 sponsor-btn-link: 'https://na.eventscloud.com/sponsor.c4l21'

--- a/_includes/homepage/jumbotron.html
+++ b/_includes/homepage/jumbotron.html
@@ -23,7 +23,7 @@
                 <div id="conferenceActions">
                     {% if site.data.conf.livestream.show %}
                         <a class="btn btn-lg jumbotron-btn" href="{{ site.data.conf.livestream.url }}">
-                            Livestream {% if site.data.conf.homepage-display == 'post' %} Archive{% endif %}
+                            {{ site.data.conf.livestream.button-label }} {% if site.data.conf.homepage-display == 'post' %} Archive{% endif %}
                         </a>
                     {% endif %}
                     {% if site.data.conf.closed-captioning.show %}


### PR DESCRIPTION
**Merge PR after Concentra email sent to registrants, likely Thursday 3/18**

This PR:
- Enables 'Livestream' button in hero, with a label of 'Registered? Join Live' per @jscaffrey 
- Removes 'Sponsor' button from hero and `/sponsors` page

Closes #159 