### PR TITLE
display date at the top of each scheduled day of events

### DIFF
--- a/_layouts/day-schedule.html
+++ b/_layouts/day-schedule.html
@@ -4,7 +4,10 @@
 <div class="container">
     <div class="row">
         <div class="col-12">
-            <h1>{{ page.title }}</h1>
+            <h1>{% assign day = page.day | slice: -1 %}
+                {% assign index = day | plus: 0 | minus: 1 %}
+                {{ page.title }} - {{site.data.conf.days[index].date}}
+            </h1>
             {% if site.data.conf.have-schedule %}
                 {% include schedule_nav.html param=page.day %}
                 {{ content }}


### PR DESCRIPTION
![Screen Shot 2021-03-16 at 1 41 27 PM](https://user-images.githubusercontent.com/10561752/111355644-f1b23280-865d-11eb-9b6d-d0bbf2b55f8e.png)

Adds some logic to display the date for each 'day of events'.

```
<h1>
{% assign day = page.day | slice: -1 %}
{% assign index = day | plus: 0 | minus: 1 %}
{{ page.title }} - {{site.data.conf.days[index].date}}
</h1>
```

That strange `{% assign index = day | plus: 0 | minus: 1 %}` line changes the data type from string to integer. 🤷🏻 

Who knows... maybe next year's conference will be two weeks. If so, this will fail.

Closes #192 