### PR TITLE
fix low contrast on class btn-warning in 'dark mode'

### DIFF
--- a/_layouts/presentation.html
+++ b/_layouts/presentation.html
@@ -161,7 +161,7 @@
             </div>
             <!-- slides -->
             {% if page.slides %}
-            <div class="talk-box-detail-value"><a href="{{ page.slides }}" class="btn btn-secondary btn-lg col-sm-12">
+            <div class="talk-box-detail-value"><a href="{{ page.slides }}" class="btn btn-warning btn-lg col-sm-12">
               <span class="glyphicon glyphicon-blackboard"></span>&nbsp;View Slides</a></div>
             {% endif %}
         </div>

--- a/assets/_scss/_global.scss
+++ b/assets/_scss/_global.scss
@@ -74,3 +74,11 @@ p {
   margin: 0;
   padding: 0;
 }
+
+// Contrast Fix for 2021 "dark mode"
+.btn-warning {
+    color: $gray-900;
+    &:hover {
+        color: $black !important;
+    }
+}


### PR DESCRIPTION
Swaps bootstrap class `btn-secondary` for `btn-warning` on the individual talk 'View Slides' button and globally updates the contrast of `btn-warning` to avoid low contrast errors. This should fix the reported issue on the individual talk pages, as well as other instances of `btn-warning` throughout the site.

closes #198