### PR TITLE
Fix: Non-visible links being captured during tab navigation

### DIFF
--- a/_includes/speaker_box.html
+++ b/_includes/speaker_box.html
@@ -34,7 +34,7 @@
             {% for talk in talks  %}
                 {% for speaker_id in talk.speakers %}
                     {% if speaker_id == speaker.id %}
-                    <p class="speaker-session">Talk: <a href="{{ talk.url }}">{{ talk.title }}</a></p>
+                    <p class="speaker-session">Talk: <a href="{{ talk.url }}" tabindex="-1">{{ talk.title }}</a></p>
                     {% endif %}
                 {% endfor %}
             {% endfor %}


### PR DESCRIPTION
This PR adds `tabindex="-1"` to session speaker boxes, taking advantage of the JS function added in #132 

Closes #178 

