### PR TITLE
add #main to all layouts, ref #174

### DIFF
--- a/_layouts/color-test.html
+++ b/_layouts/color-test.html
@@ -1,7 +1,7 @@
 {% include header.html %}
 {% include search_results.html %}
 
-<div class="CT-body">
+<div class="CT-body" id="main">
 {{ content }}
 </div>
 

--- a/_layouts/day-menu.html
+++ b/_layouts/day-menu.html
@@ -2,6 +2,7 @@
 {% include search_results.html %}
 
 {% assign menu = site.data[page.menu] %}
+<div id="main">{% comment %} #main element needed for skip-menu link but we can't add it inside the loop {% endcomment %}</div>
 {% for meal in menu %}
 <section>
     <div class="container">

--- a/_layouts/day-schedule.html
+++ b/_layouts/day-schedule.html
@@ -1,7 +1,7 @@
 {% include header.html %}
 {% include search_results.html %}
 
-<div class="container">
+<div class="container" id="main">
     <div class="row">
         <div class="col-12">
             <h1>{% assign day = page.day | slice: -1 %}

--- a/_layouts/presentation.html
+++ b/_layouts/presentation.html
@@ -16,7 +16,7 @@
     {% assign page_date = page.startTime %}
 {% endif %}
 
-<div class="container">
+<div class="container" id="main">
     <div class="row">
         <div class="col-12 col-sm-8 col-md-9">
 


### PR DESCRIPTION
This should make the "skip menu" link work on many pages where it does not currently, such as /schedule/day-N/, /workshops/\*, /keynotes/\*, and /talks/\*. To test: visit the page, use the main link, the URL hash should update and you should visible move to the start of the content.

I know we're not using menus this year but I added it to that page and it was the only one where it's a little awkward because all the content is inside a loop:

```html
{% assign menu = site.data[page.menu] %}
<div id="main">{% comment %} #main element needed for skip-menu link but we can't add it inside the loop {% endcomment %}</div>
{% for meal in menu %}
```

I don't know if an empty div is appropriate.